### PR TITLE
added --list flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ In your command line type `trellis`.
 
 By default it will only look for lists named `Todo`. However you can edit the `getLists` area in `~/.trellis/config.json` to add, edit or delete any lists you like.
 
+### One shot list view
+
+If you want to look at a specific set of lists but you don't want to see them all the time (for example you want to see all of your "Backlog" lists just this once) then you can specify the list using the `--list` flag.
+
+e.g. `trellis --list "Backlog"`
+
+Note: The quotation marks are not strictly needed if the list name is only one word.
+
 ## Example
 
 ![Screenshot](example.png)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const fs = require('fs')
 const Trello = require('trello')
 const config = require('nconf')
 const chalk = require('chalk')
+const argv = require('yargs').argv
 const terminalLink = require('terminal-link')
 
 // TODO: Add error state if token is rejected
@@ -27,7 +28,7 @@ if (!fs.existsSync(configPath)) {
 const configData = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
 const trello = new Trello(configData.appKey, configData.appToken)
-const listNameArray = configData.getLists
+const listNameArray = (argv.list) ? [argv.list] : configData.getLists
 
 trello.makeRequest('get', '/1/members/me/boards', {}, function(err, boards) {
   boards.forEach(board => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxleigh81/trellis",
-  "version": "1.1.3",
+  "version": "1.2.3",
   "description": "A node app which will list items from your trello boards",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Adds the ability for users to temporarily specify a list by adding a `--list` flag.

e.g. `trellis --flag Backlog`

Closes #9 